### PR TITLE
Fix runtime panic GLIBC_2.32 not found

### DIFF
--- a/codeship/build.sh
+++ b/codeship/build.sh
@@ -7,4 +7,4 @@ set -e
 set -x
 
 # Build all the things
-go build -ldflags="-s -w" -o bin/builder  cron/builder/main.go
+CGO_ENABLED=0 go build -ldflags="-s -w" -o bin/builder  cron/builder/main.go


### PR DESCRIPTION
### Fixed
- Fix AWS error "version GLIBC_2.32 not found": add CGO_ENABLED=0 to force Go to do static linking.

[ITSE-864](https://itse.youtrack.cloud/issue/ITSE-864)